### PR TITLE
More d3 rendering

### DIFF
--- a/app/src/SettingsDialog.js
+++ b/app/src/SettingsDialog.js
@@ -1,64 +1,44 @@
 import React, { useState } from 'react'
 import { Button, Col, Form, Modal, Row } from 'react-bootstrap'
 
-export function SettingsDialog({ onHide, settings: paramSettings, onSettings }) {
+export function SettingsDialog({
+  onHide,
+  settings: paramSettings,
+  onSettings
+}) {
   const [settings, setSettings] = useState(paramSettings)
   const {
     chunkSize,
-    forceSteps,
     linkSteps,
     strengthCenter,
-    strengthXY,
-    forceType,
     theta,
     sequenceThickness,
-    linkThickness,
+    linkThickness
   } = settings
   return (
-    <Modal show={true} onHide={onHide} size="lg">
+    <Modal show={true} onHide={onHide} size='lg'>
       <Modal.Header closeButton>
         <Modal.Title>Settings</Modal.Title>
       </Modal.Header>
 
       <Modal.Body>
         <Form
-          onSubmit={event => {
+          onSubmit={(event) => {
             event.preventDefault()
             onSettings({
               ...settings,
               chunkSize: +chunkSize,
-              forceType: forceType,
-              forceSteps: +forceSteps,
               linkSteps: +linkSteps,
               strengthCenter: +strengthCenter,
               theta: +theta,
               sequenceThickness: +sequenceThickness,
-              linkThickness: +linkThickness,
+              linkThickness: +linkThickness
             })
             onHide()
           }}
         >
           <Form.Group as={Row}>
-            <Form.Label column sm="4">
-              Number of simulation steps for the nodes
-              <Form.Text muted>Used in the force-based layout simulation</Form.Text>
-            </Form.Label>
-            <Col>
-              <Form.Control
-                type="number"
-                value={forceSteps}
-                onChange={event => {
-                  const val = event.target.value
-                  setSettings(settings => ({
-                    ...settings,
-                    forceSteps: val,
-                  }))
-                }}
-              />
-            </Col>
-          </Form.Group>
-          <Form.Group as={Row}>
-            <Form.Label column sm="4">
+            <Form.Label column sm='4'>
               Number of simulation steps for the links
               <Form.Text muted>
                 Increases the rigidity of the link based constraints
@@ -66,171 +46,128 @@ export function SettingsDialog({ onHide, settings: paramSettings, onSettings }) 
             </Form.Label>
             <Col>
               <Form.Control
-                type="number"
+                type='number'
                 value={linkSteps}
-                onChange={event => {
+                onChange={(event) => {
                   const val = event.target.value
-                  setSettings(settings => ({
+                  setSettings((settings) => ({
                     ...settings,
-                    linkSteps: val,
+                    linkSteps: val
                   }))
                 }}
               />
             </Col>
           </Form.Group>
           <Form.Group as={Row}>
-            <Form.Label column sm="4">
+            <Form.Label column sm='4'>
               Sequence chunk size
               <Form.Text muted>
-                If a contig is of length 5000, then chunk length 1000 would become 5
-                segments. Note that contigs smaller than the chunk length may not be
-                proportionally sized
+                If a contig is of length 5000, then chunk length 1000 would
+                become 5 segments. Note that contigs smaller than the chunk
+                length may not be proportionally sized
               </Form.Text>
             </Form.Label>
             <Col>
               <Form.Control
-                type="number"
+                type='number'
                 value={chunkSize}
-                onChange={event => {
+                onChange={(event) => {
                   const val = event.target.value
-                  setSettings(settings => ({
+                  setSettings((settings) => ({
                     ...settings,
-                    chunkSize: val,
+                    chunkSize: val
                   }))
                 }}
               />
             </Col>
           </Form.Group>
           <Form.Group as={Row}>
-            <Form.Label column sm="4">
+            <Form.Label column sm='4'>
               Theta
-              <Form.Text muted>Parameter for the force directed layout</Form.Text>
-            </Form.Label>
-            <Col>
-              <Form.Control
-                type="number"
-                value={theta}
-                onChange={event => {
-                  const val = event.target.value
-                  setSettings(settings => ({
-                    ...settings,
-                    theta: val,
-                  }))
-                }}
-              />
-            </Col>
-          </Form.Group>
-          <Form.Group as={Row}>
-            <Form.Label column sm="4">
-              Strength (force xy)
               <Form.Text muted>
-                This parameter should be between [0,1], applies to the XY layout
+                Parameter for the force directed layout
               </Form.Text>
             </Form.Label>
             <Col>
               <Form.Control
-                type="number"
-                value={strengthXY}
-                onChange={event => {
+                type='number'
+                value={theta}
+                onChange={(event) => {
                   const val = event.target.value
-                  setSettings(settings => ({
+                  setSettings((settings) => ({
                     ...settings,
-                    strengthXY: val,
+                    theta: val
                   }))
                 }}
               />
             </Col>
           </Form.Group>
           <Form.Group as={Row}>
-            <Form.Label column sm="4">
+            <Form.Label column sm='4'>
               Strength (particle charge)
               <Form.Text muted>
-                This value is like a charged particle force, by being negative it keeps
-                things farther apart
+                This value is like a charged particle force, by being negative
+                it keeps things farther apart
               </Form.Text>
             </Form.Label>
             <Col>
               <Form.Control
-                type="number"
+                type='number'
                 value={strengthCenter}
-                onChange={event => {
+                onChange={(event) => {
                   const val = event.target.value
-                  setSettings(settings => ({
+                  setSettings((settings) => ({
                     ...settings,
-                    strengthCenter: val,
+                    strengthCenter: val
                   }))
                 }}
               />
             </Col>
           </Form.Group>
           <Form.Group as={Row}>
-            <Form.Label column sm="4">
-              Force type
-              <Form.Text muted>
-                Force XY results in a circular style layout that can be helpful for more
-                disjoint graphs, force center is default
-              </Form.Text>
-            </Form.Label>
-            <Col>
-              <Form.Control
-                value={forceType}
-                onChange={event =>
-                  setSettings(settings => ({
-                    ...settings,
-                    forceType: event.target.value,
-                  }))
-                }
-                as="select"
-              >
-                <option>center</option>
-                <option>xy</option>
-              </Form.Control>
-            </Col>
-          </Form.Group>
-          <Form.Group as={Row}>
-            <Form.Label column sm="4">
+            <Form.Label column sm='4'>
               Sequence thickness
             </Form.Label>
             <Col>
               <input
-                type="range"
+                type='range'
                 min={1}
                 max={100}
                 style={{ width: '100%' }}
                 value={sequenceThickness}
-                onChange={event => {
+                onChange={(event) => {
                   const val = event.target.value
-                  setSettings(settings => ({
+                  setSettings((settings) => ({
                     ...settings,
-                    sequenceThickness: val,
+                    sequenceThickness: val
                   }))
                 }}
               />
             </Col>
           </Form.Group>
           <Form.Group as={Row}>
-            <Form.Label column sm="4">
+            <Form.Label column sm='4'>
               Link thickness
             </Form.Label>
             <Col>
               <input
-                type="range"
+                type='range'
                 min={1}
                 max={100}
                 style={{ width: '100%' }}
                 value={linkThickness}
-                onChange={event => {
+                onChange={(event) => {
                   const val = event.target.value
-                  setSettings(settings => ({
+                  setSettings((settings) => ({
                     ...settings,
-                    linkThickness: val,
+                    linkThickness: val
                   }))
                 }}
               />
             </Col>
           </Form.Group>
 
-          <Button type="submit">Submit</Button>
+          <Button type='submit'>Submit</Button>
         </Form>
       </Modal.Body>
     </Modal>

--- a/app/src/Sidebar.js
+++ b/app/src/Sidebar.js
@@ -10,7 +10,7 @@ export function Sidebar({
   onColorChange,
   onPathDraw,
   onRedraw,
-  colorScheme,
+  colorScheme
 }) {
   return (
     <div>
@@ -18,8 +18,8 @@ export function Sidebar({
       <Form.Label>Color</Form.Label>
       <Form.Control
         value={colorScheme}
-        onChange={event => onColorChange(event.target.value)}
-        as="select"
+        onChange={(event) => onColorChange(event.target.value)}
+        as='select'
       >
         <option>JustGrey</option>
         <option>Turbo</option>
@@ -31,35 +31,24 @@ export function Sidebar({
       <br />
       <Form.Group>
         <Form.Check
-          onChange={event => {
+          onChange={(event) => {
             onPathDraw(event.target.checked)
           }}
-          type="checkbox"
-          label="Draw paths"
+          type='checkbox'
+          label='Draw paths'
           checked={drawPaths}
         />
       </Form.Group>
       <Form.Group>
         <Form.Check
-          onChange={event => {
+          onChange={(event) => {
             onDrawLabels(event.target.checked)
           }}
-          type="checkbox"
-          label="Draw labels"
+          type='checkbox'
+          label='Draw labels'
           checked={drawLabels}
         />
       </Form.Group>
-      <Form.Group>
-        <Form.Check
-          onChange={event => {
-            onDrag(event.target.checked)
-          }}
-          type="checkbox"
-          label="Enable panning/zooming?"
-          checked={drag}
-        />
-      </Form.Group>
-      <br />
       <Button onClick={() => onRedraw()}>Redraw</Button>
     </div>
   )

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -72,7 +72,6 @@ const Graph = React.forwardRef((props, ref) => {
       })
     )
   }, [graph.paths])
-  console.log({ colors }, graph.paths)
 
   useEffect(() => {
     if (ref.current) {
@@ -130,22 +129,34 @@ const Graph = React.forwardRef((props, ref) => {
           } else {
             const [s1, t1] = nodePathMap[d.source.id]
             const [s2, t2] = nodePathMap[d.target.id]
-            const [cx1, cy1] = projectLine(
-              s1[0],
-              s1[1],
-              t1[0],
-              t1[1],
-              60 + d.pathIndex * 30
-            )
-            const [cx2, cy2] = projectLine(
-              s2[0],
-              s2[1],
-              t2[0],
-              t2[1],
-              60 + d.pathIndex * 30
-            )
+            const m1 = (y2 - y1) / (x2 - x1)
+            const m2 = (s1[1] - t1[1]) / (s1[0] - t1[0])
+            const m3 = (s2[1] - t2[1]) / (s2[0] - t2[0])
 
-            return `M ${x1} ${y1} C ${cx1} ${cy1}, ${cx2} ${cy2}, ${x2}, ${y2}`
+            if (Math.abs(m1 - m2) < 0.2 || Math.abs(m1 - m3) < 0.2) {
+              const dx = x2 - x1
+              const dy = y2 - y1
+              const dr = Math.sqrt(dx * dx + dy * dy) + Math.random() * 40
+              const sweep = d.pathIndex % 2
+              return `M${x1},${y1}A${dr},${dr} 0 0,${sweep} ${x2},${y2}`
+            } else {
+              const [cx1, cy1] = projectLine(
+                s1[0],
+                s1[1],
+                t1[0],
+                t1[1],
+                20 + d.pathIndex * 30
+              )
+              const [cx2, cy2] = projectLine(
+                s2[0],
+                s2[1],
+                t2[0],
+                t2[1],
+                20 + d.pathIndex * 30
+              )
+
+              return `M ${x1} ${y1} C ${cx1} ${cy1}, ${cx2} ${cy2}, ${x2}, ${y2}`
+            }
           }
         })
 

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect } from 'react'
+import React, { useRef, useMemo, useEffect } from 'react'
 import { hsl } from 'd3-color'
 import * as d3drag from 'd3-drag'
 import { select } from 'd3-selection'
@@ -40,6 +40,9 @@ const Graph = React.forwardRef((props, ref) => {
       console.log('no feature click configured')
     }
   } = props
+
+  const dragRef = useRef()
+  dragRef.current = drag
 
   const data = useMemo(() => {
     return reprocessGraph(graph, chunkSize)
@@ -96,7 +99,7 @@ const Graph = React.forwardRef((props, ref) => {
       }
       const simulation = forceSimulation().nodes(nodes)
       const charge_force = forceManyBody().strength(strengthCenter).theta(theta)
-      const center_force = forceCenter(width / 2, height / 2)
+      const center_force = forceCenter(width / 3, height / 3)
       const link_force = forceLink(links)
         .id((d) => d.id)
         .distance((link) => (link.sequence ? 1 : 10))
@@ -112,34 +115,41 @@ const Graph = React.forwardRef((props, ref) => {
       const svg = select(ref.current)
       const g = svg.append('g')
       const paths = generatePaths(links, graph.nodes)
-      // const edges = generateEdges(links, data.links)
+      const edges = generateEdges(links, data.links)
+      console.log({ edges })
 
-      const link = g
-        .selectAll('line')
-        .data(links)
-        .join('path')
-        .attr('stroke', (d) => {
-          const same = d.linkNum !== undefined
-          if (same) {
-            const nodeIndex = paths.findIndex((path) => {
-              return path.original.id === d.id
-            })
-            return color.startsWith('Just')
-              ? color.replace('Just', '').toLowerCase()
-              : hsl(
-                  d3interpolate[`interpolate${color}`](nodeIndex / paths.length)
-                ).darker()
-          } else {
-            return 'grey'
-          }
-        })
-        .attr('fill', 'none')
-        .attr('stroke-width', (d) => {
-          return d.linkNum !== undefined ? sequenceThickness : linkThickness
-        })
-        .on('click', (event, d) => {
-          onFeatureClick(d)
-        })
+      let link
+      if (!drawPaths) {
+        link = g
+          .selectAll('line')
+          .data(links)
+          .join('path')
+          .attr('stroke', (d) => {
+            const same = d.linkNum !== undefined
+            if (same) {
+              const nodeIndex = paths.findIndex((path) => {
+                return path.original.id === d.id
+              })
+              return color.startsWith('Just')
+                ? color.replace('Just', '').toLowerCase()
+                : hsl(
+                    d3interpolate[`interpolate${color}`](
+                      nodeIndex / paths.length
+                    )
+                  ).darker()
+            } else {
+              return 'grey'
+            }
+          })
+          .attr('fill', 'none')
+          .attr('stroke-width', (d) => {
+            return d.linkNum !== undefined ? sequenceThickness : linkThickness
+          })
+          .on('click', (_, d) => {
+            onFeatureClick(d)
+          })
+      } else {
+      }
 
       const node = g
         .selectAll('circle')
@@ -157,7 +167,7 @@ const Graph = React.forwardRef((props, ref) => {
           'd',
           (d) => `M ${d.source.x} ${d.source.y} L ${d.target.x} ${d.target.y}`
         )
-        .attr('id', (d, i) => 'edgepath-' + i)
+        .attr('id', (_, i) => 'edgepath-' + i)
 
       const edgelabels = g
         .selectAll('.edgelabel')
@@ -165,14 +175,14 @@ const Graph = React.forwardRef((props, ref) => {
         .enter()
         .append('text')
         .attr('dy', 12)
-        .attr('id', (d, i) => 'edgelabel-' + i)
+        .attr('id', (_, i) => 'edgelabel-' + i)
 
       edgelabels
         .append('textPath')
-        .attr('href', (d, i) => `#edgepath-${i}`)
+        .attr('href', (_, i) => `#edgepath-${i}`)
         .attr('startOffset', '50%')
         .attr('text-anchor', 'middle')
-        .text((d, i) => {
+        .text((d) => {
           const sid = d.source.id.slice(0, d.source.id.lastIndexOf('-'))
           const tid = d.target.id.slice(0, d.target.id.lastIndexOf('-'))
           const same = sid === tid && d.id
@@ -205,17 +215,11 @@ const Graph = React.forwardRef((props, ref) => {
         .on('end', drag_end)
 
       drag_handler(node)
-
-      if (drag) {
-        const zoom_handler = d3zoom()
-        zoom_handler.on('zoom', (event) => {
-          if (drag) {
-            g.attr('transform', event.transform)
-          }
-        })
-
-        zoom_handler(svg)
-      }
+      const zoom_handler = d3zoom()
+      zoom_handler.on('zoom', (event) => {
+        g.attr('transform', event.transform)
+      })
+      zoom_handler(svg)
     }
   }, [
     data.links,
@@ -227,7 +231,6 @@ const Graph = React.forwardRef((props, ref) => {
     linkThickness,
     theta,
     width,
-    drag,
     redraw,
     height
   ])
@@ -238,6 +241,7 @@ const Graph = React.forwardRef((props, ref) => {
       height='100%'
       ref={ref}
       style={{ fontSize: drawLabels ? 10 : 0 }}
+      viewBox={[0, 0, width, height].toString()}
     ></svg>
   )
 })

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -61,11 +61,62 @@ const Graph = React.forwardRef((props, ref) => {
       ref.current.innerHTML = ''
       function tickActions() {
         node.attr('cx', (d) => d.x).attr('cy', (d) => d.y)
-        link
-          .attr('x1', (d) => d.source.x)
-          .attr('y1', (d) => d.source.y)
-          .attr('x2', (d) => d.target.x)
-          .attr('y2', (d) => d.target.y)
+
+        // from https://stackoverflow.com/questions/16358905/
+        link.attr('d', function (d) {
+          var x1 = d.source.x,
+            y1 = d.source.y,
+            x2 = d.target.x,
+            y2 = d.target.y,
+            drx = 0,
+            dry = 0,
+            xRotation = 0, // degrees
+            largeArc = 0, // 1 or 0
+            sweep = 1 // 1 or 0
+
+          // Self edge.
+          if (x1 === x2 && y1 === y2) {
+            // Fiddle with this angle to get loop oriented.
+            xRotation = -45
+
+            // Needs to be 1.
+            largeArc = 1
+
+            // Change sweep to change orientation of loop.
+            //sweep = 0;
+
+            // Make drx and dry different to get an ellipse
+            // instead of a circle.
+            drx = 30
+            dry = 20
+
+            // For whatever reason the arc collapses to a point if the beginning
+            // and ending points of the arc are the same, so kludge it.
+            x2 = x2 + 1
+            y2 = y2 + 1
+          }
+
+          return (
+            'M' +
+            x1 +
+            ',' +
+            y1 +
+            'A' +
+            drx +
+            ',' +
+            dry +
+            ' ' +
+            xRotation +
+            ',' +
+            largeArc +
+            ',' +
+            sweep +
+            ' ' +
+            x2 +
+            ',' +
+            y2
+          )
+        })
 
         if (edgepaths) {
           edgepaths.attr(
@@ -97,7 +148,7 @@ const Graph = React.forwardRef((props, ref) => {
       const link = g
         .selectAll('line')
         .data(links)
-        .join('line')
+        .join('path')
         .attr('stroke', (d) => {
           const same = d.linkNum !== undefined
           if (same) {

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect } from 'react'
+import React, { useMemo, useEffect } from 'react'
 import { hsl } from 'd3-color'
 import { path } from 'd3-path'
 import * as d3drag from 'd3-drag'
@@ -7,9 +7,7 @@ import {
   forceManyBody,
   forceLink,
   forceSimulation,
-  forceCenter,
-  forceX,
-  forceY
+  forceCenter
 } from 'd3-force'
 import * as d3interpolate from 'd3-scale-chromatic'
 import { zoom as d3zoom } from 'd3-zoom'
@@ -31,14 +29,11 @@ const Graph = React.forwardRef((props, ref) => {
     drag = false,
     settings: {
       chunkSize = 1000,
-      forceSteps = 500,
       linkSteps = 3,
       sequenceThickness = 10,
       linkThickness = 2,
       theta = 0.9,
-      forceType = 'center',
-      strengthCenter = -50,
-      strengthXY = 0.3
+      strengthCenter = -50
     },
     color = 'Rainbow',
     width = 2000,
@@ -80,14 +75,16 @@ const Graph = React.forwardRef((props, ref) => {
         }
       }
       const simulation = forceSimulation().nodes(nodes)
-
-      const link_force = forceLink(links).id((d) => d.id)
-      const charge_force = forceManyBody().strength(-50)
+      const charge_force = forceManyBody().strength(strengthCenter).theta(theta)
       const center_force = forceCenter(width / 2, height / 2)
+      const link_force = forceLink(links)
+        .id((d) => d.id)
+        .distance((link) => (link.sequence ? 1 : 10))
+        .iterations(linkSteps)
 
       simulation
-        .force('charge_force', charge_force)
-        .force('center_force', center_force)
+        .force('charge', charge_force)
+        .force('center', center_force)
         .force('links', link_force)
 
       simulation.on('tick', tickActions)
@@ -156,7 +153,6 @@ const Graph = React.forwardRef((props, ref) => {
           .attr('xlink:href', (d, i) => `#edgepath-${i}`)
           .style('pointer-events', 'none')
           .text((d, i) => {
-            console.log({ d })
             const sid = d.source.id.slice(0, d.source.id.lastIndexOf('-'))
             const tid = d.target.id.slice(0, d.target.id.lastIndexOf('-'))
             const same = sid === tid
@@ -209,14 +205,13 @@ const Graph = React.forwardRef((props, ref) => {
     linkSteps,
     strengthCenter,
     drawLabels,
+    sequenceThickness,
+    linkThickness,
     theta,
-    forceType,
     width,
     drag,
     redraw,
-    height,
-    strengthXY,
-    forceSteps
+    height
   ])
   // const paths = generatePaths(links, graph.nodes)
   // const edges = generateEdges(links, data.links)

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef, useEffect } from 'react'
 import { hsl } from 'd3-color'
 import { path } from 'd3-path'
+import * as d3drag from 'd3-drag'
 import { select } from 'd3-selection'
 import {
   forceManyBody,
@@ -49,15 +50,6 @@ const Graph = React.forwardRef((props, ref) => {
     }
   } = props
 
-  const zoom = useRef(
-    d3zoom()
-      .extent([
-        [0, 0],
-        [width, height]
-      ])
-      .scaleExtent([0.1, 8])
-  )
-
   const data = useMemo(() => {
     return reprocessGraph(graph, chunkSize)
   }, [chunkSize, graph])
@@ -69,50 +61,151 @@ const Graph = React.forwardRef((props, ref) => {
       })
     )
   }, [graph.paths])
-  const links = useMemo(() => {
-    const links = data.links.map((d) =>
-      Object.create({ ...d, x: Math.random(), y: Math.random() })
-    )
-    const nodes = data.nodes.map((d) =>
-      Object.create({ ...d, x: Math.random(), y: Math.random() })
-    )
-    const simulation = forceSimulation(nodes)
-      .force(
-        'link',
-        forceLink(links)
-          .id((d) => d.id)
-          .distance((link) => {
-            return link.sequence ? 1 : 10
-          })
-          .iterations(linkSteps)
+  useEffect(() => {
+    if (ref.current) {
+      const links = data.links.map((d) =>
+        Object.create({ ...d, x: Math.random(), y: Math.random() })
       )
-      .force('charge', forceManyBody().strength(strengthCenter).theta(theta))
+      const nodes = data.nodes.map((d) =>
+        Object.create({ ...d, x: Math.random(), y: Math.random() })
+      )
+      // const simulation = forceSimulation(nodes)
+      //   .force(
+      //     'link',
+      //     forceLink(links)
+      //       .id((d) => d.id)
+      //       .distance((link) => {
+      //         return link.sequence ? 1 : 10
+      //       })
+      //       .iterations(linkSteps)
+      //   )
+      //   .force('charge', forceManyBody().strength(strengthCenter).theta(theta))
 
-    if (forceType === 'center') {
-      simulation.force('center', forceCenter(width / 3, height / 3))
-    } else if (forceType === 'xy') {
+      // if (forceType === 'center') {
+      //   simulation.force('center', forceCenter(width / 3, height / 3))
+      // } else if (forceType === 'xy') {
+      //   simulation
+      //     .force(
+      //       'x',
+      //       forceX()
+      //         .x(width / 3)
+      //         .strength(strengthXY)
+      //     )
+      //     .force(
+      //       'y',
+      //       forceY()
+      //         .y(height / 3)
+      //         .strength(strengthXY)
+      //     )
+      // }
+
+      // for (let i = 0; i < forceSteps; ++i) {
+      // simulation.tick()
+      // }
+
+      ref.current.innerHTML = ''
+      function tickActions() {
+        //update circle positions each tick of the simulation
+        node
+          .attr('cx', function (d) {
+            return d.x
+          })
+          .attr('cy', function (d) {
+            return d.y
+          })
+
+        //update link positions
+        link
+          .attr('x1', function (d) {
+            return d.source.x
+          })
+          .attr('y1', function (d) {
+            return d.source.y
+          })
+          .attr('x2', function (d) {
+            return d.target.x
+          })
+          .attr('y2', function (d) {
+            return d.target.y
+          })
+      }
+      const simulation = forceSimulation().nodes(nodes)
+
+      const link_force = forceLink(links).id((d) => d.id)
+      const charge_force = forceManyBody().strength(-100)
+      const center_force = forceCenter(width / 2, height / 2)
+
       simulation
-        .force(
-          'x',
-          forceX()
-            .x(width / 3)
-            .strength(strengthXY)
-        )
-        .force(
-          'y',
-          forceY()
-            .y(height / 3)
-            .strength(strengthXY)
-        )
-    }
+        .force('charge_force', charge_force)
+        .force('center_force', center_force)
+        .force('links', link_force)
 
-    for (let i = 0; i < forceSteps; ++i) {
-      simulation.tick()
+      //add tick instructions:
+      simulation.on('tick', tickActions)
+
+      const svg = select(ref.current)
+      const g = svg.append('g')
+
+      const link = g
+        .append('g')
+        .attr('stroke', '#999')
+        .attr('stroke-opacity', 0.6)
+        .selectAll('line')
+        .data(links)
+        .join('line')
+
+      const node = g
+        .append('g')
+        .attr('stroke', '#fff')
+        .attr('stroke-width', 1.5)
+        .selectAll('circle')
+        .data(nodes)
+        .join('circle')
+        .attr('r', 5)
+        .attr('fill', color)
+
+      function drag_start(event, d) {
+        if (!event.active) {
+          simulation.alphaTarget(0.3).restart()
+        }
+        console.log({ d, event })
+
+        d.fx = event.x
+        d.fy = event.y
+      }
+
+      //make sure you can't drag the circle outside the box
+      function drag_drag(event, d) {
+        d.fx = event.x
+        d.fy = event.y
+      }
+
+      function drag_end(event, d) {
+        if (!event.active) simulation.alphaTarget(0)
+        d.fx = null
+        d.fy = null
+      }
+
+      //add drag capabilities
+      var drag_handler = d3drag
+        .drag()
+        .on('start', drag_start)
+        .on('drag', drag_drag)
+        .on('end', drag_end)
+
+      drag_handler(node)
+
+      if (drag) {
+        const zoomer = d3zoom()
+        zoomer.on('zoom', (event) => {
+          if (drag) {
+            g.attr('transform', event.transform)
+          }
+        })
+
+        zoomer(svg)
+      }
     }
-    // used for redrawing
-    // eslint-disable-next-line no-unused-vars
-    const m = redraw
-    return links
   }, [
     data.links,
     data.nodes,
@@ -120,38 +213,23 @@ const Graph = React.forwardRef((props, ref) => {
     strengthCenter,
     theta,
     forceType,
-    redraw,
     width,
+    drag,
     height,
     strengthXY,
-    forceSteps
+    forceSteps,
+    ref.current
   ])
+  // const paths = generatePaths(links, graph.nodes)
+  // const edges = generateEdges(links, data.links)
 
-  useEffect(() => {
-    // zoom logic, similar to https://observablehq.com/@d3/zoom
-    // toggling logic from https://stackoverflow.com/a/29762389/2129219
-    const svg = select(ref.current)
-    if (drag) {
-      svg.call(
-        zoom.current.on('zoom', (event) => {
-          select(gref.current).attr('transform', event.transform)
-        })
-      )
-    } else {
-      svg.on('.zoom', null)
-    }
-  }, [drag, height, ref, width, zoom])
-
-  const paths = generatePaths(links, graph.nodes)
-  const edges = generateEdges(links, data.links)
-
-  const nodePathMap = {}
-  for (let i = 0; i < paths.length; i++) {
-    const p = paths[i]
-    const l = p.links.length
-    nodePathMap[`${p.original.id}-start`] = [p.links[1], p.links[0]]
-    nodePathMap[`${p.original.id}-end`] = [p.links[l - 2], p.links[l - 1]]
-  }
+  // const nodePathMap = {}
+  // for (let i = 0; i < paths.length; i++) {
+  //   const p = paths[i]
+  //   const l = p.links.length
+  //   nodePathMap[`${p.original.id}-start`] = [p.links[1], p.links[0]]
+  //   nodePathMap[`${p.original.id}-end`] = [p.links[l - 2], p.links[l - 1]]
+  // }
 
   return (
     <svg
@@ -161,127 +239,7 @@ const Graph = React.forwardRef((props, ref) => {
       style={{ fontSize: 10 }}
       viewBox={[0, 0, width, height].toString()}
     >
-      <g ref={gref}>
-        {edges.map((p, j) => {
-          const x1 = p.links[0][0]
-          const y1 = p.links[0][1]
-          const x2 = p.links[1][0]
-          const y2 = p.links[1][1]
-
-          if (drawPaths) {
-            const [s1, t1] = nodePathMap[p.original.source]
-            const [s2, t2] = nodePathMap[p.original.target]
-            const m1 = (y2 - y1) / (x2 - x1)
-            const m2 = (s1[1] - t1[1]) / (s1[0] - t1[0])
-            const m3 = (s2[1] - t2[1]) / (s2[0] - t2[0])
-            if (Math.abs(m1 - m2) < 0.2 || Math.abs(m1 - m3) < 0.2) {
-              return p.original.paths
-                ? p.original.paths.map((pp, index) => {
-                    const dx = x2 - x1
-                    const dy = y2 - y1
-                    const dr = Math.sqrt(dx * dx + dy * dy) + Math.random() * 40
-                    const sweep = index % 2
-                    const cpath = `M${x1},${y1}A${dr},${dr} 0 0,${sweep} ${x2},${y2}`
-                    return (
-                      <path
-                        key={`${cpath}-${index}`}
-                        d={cpath}
-                        strokeWidth={linkThickness}
-                        stroke={colors[pp]}
-                        fill='none'
-                        onClick={() => onFeatureClick(p.original)}
-                      >
-                        <title>{pp}</title>
-                      </path>
-                    )
-                  })
-                : null
-            }
-
-            return p.original.paths
-              ? p.original.paths.map((pp, index) => {
-                  const [cx1, cy1] = projectLine(
-                    s1[0],
-                    s1[1],
-                    t1[0],
-                    t1[1],
-                    60 + index * 30
-                  )
-                  const [cx2, cy2] = projectLine(
-                    s2[0],
-                    s2[1],
-                    t2[0],
-                    t2[1],
-                    60 + index * 30
-                  )
-
-                  const cpath = path()
-                  cpath.moveTo(x1, y1)
-                  cpath.bezierCurveTo(cx1, cy1, cx2, cy2, x2, y2)
-
-                  return (
-                    <path
-                      key={`${cpath.toString()}-${index}`}
-                      d={cpath}
-                      strokeWidth={linkThickness}
-                      stroke={colors[pp]}
-                      fill='none'
-                      onClick={() => onFeatureClick(p.original)}
-                    >
-                      <title>{pp}</title>
-                    </path>
-                  )
-                })
-              : null
-          } else {
-            const [s1, t1] = nodePathMap[p.original.source]
-            const [s2, t2] = nodePathMap[p.original.target]
-            const m1 = (y2 - y1) / (x2 - x1)
-            const m2 = (s1[1] - t1[1]) / (s1[0] - t1[0])
-            const m3 = (s2[1] - t2[1]) / (s2[0] - t2[0])
-            const line = d3shape.line().context(null)
-            const xRot = 90
-            const sweep = 0 // 1 or 0
-            const largeArc = 1
-            const drx = -30
-            const dry = -20
-            const path =
-              p.original.loop && !(m1 - m2 < 0.5 || m1 - m3 < 0.5)
-                ? `M${x1},${y1}A${drx},${dry} ${xRot},${largeArc},${sweep} ${x2},${y2}`
-                : line(p.links)
-
-            return (
-              <path
-                key={`${path.toString()}-${j}`}
-                d={path}
-                strokeWidth={linkThickness}
-                stroke='black'
-                fill='none'
-                onClick={() => onFeatureClick(p.original)}
-              />
-            )
-          }
-        })}
-
-        {paths.map((p, i) => {
-          const stroke = color.startsWith('Just')
-            ? color.replace('Just', '').toLowerCase()
-            : hsl(
-                d3interpolate[`interpolate${color}`](i / paths.length)
-              ).darker()
-
-          return (
-            <Path
-              key={p.original.id}
-              sequenceThickness={sequenceThickness}
-              drawLabels={drawLabels}
-              path={p}
-              stroke={stroke}
-              onFeatureClick={onFeatureClick}
-            />
-          )
-        })}
-      </g>
+      <g ref={gref}></g>
     </svg>
   )
 })

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -53,17 +53,9 @@ const Graph = React.forwardRef((props, ref) => {
     return reprocessGraph(graph, chunkSize)
   }, [chunkSize, graph])
 
-  const colors = useMemo(() => {
-    return Object.fromEntries(
-      (graph.paths || []).map((p, i) => {
-        return [p.name, schemeCategory10[i]]
-      })
-    )
-  }, [graph.paths])
-
-  console.log({ colors })
   useEffect(() => {
     if (ref.current) {
+      // clone nodes so that redrawing will reposition them
       const links = data.links.map((d) => ({
         ...d
       }))
@@ -71,79 +63,21 @@ const Graph = React.forwardRef((props, ref) => {
         ...d
       }))
 
-      // const simulation = forceSimulation(nodes)
-      //   .force(
-      //     'link',
-      //     forceLink(links)
-      //       .id((d) => d.id)
-      //       .distance((link) => {
-      //         return link.sequence ? 1 : 10
-      //       })
-      //       .iterations(linkSteps)
-      //   )
-      //   .force('charge', forceManyBody().strength(strengthCenter).theta(theta))
-
-      // if (forceType === 'center') {
-      //   simulation.force('center', forceCenter(width / 3, height / 3))
-      // } else if (forceType === 'xy') {
-      //   simulation
-      //     .force(
-      //       'x',
-      //       forceX()
-      //         .x(width / 3)
-      //         .strength(strengthXY)
-      //     )
-      //     .force(
-      //       'y',
-      //       forceY()
-      //         .y(height / 3)
-      //         .strength(strengthXY)
-      //     )
-      // }
-
-      // for (let i = 0; i < forceSteps; ++i) {
-      // simulation.tick()
-      // }
-
       ref.current.innerHTML = ''
       function tickActions() {
-        //update circle positions each tick of the simulation
-        node
-          .attr('cx', function (d) {
-            return d.x
-          })
-          .attr('cy', function (d) {
-            return d.y
-          })
-
-        //update link positions
+        node.attr('cx', (d) => d.x).attr('cy', (d) => d.y)
         link
-          .attr('x1', function (d) {
-            return d.source.x
-          })
-          .attr('y1', function (d) {
-            return d.source.y
-          })
-          .attr('x2', function (d) {
-            return d.target.x
-          })
-          .attr('y2', function (d) {
-            return d.target.y
-          })
+          .attr('x1', (d) => d.source.x)
+          .attr('y1', (d) => d.source.y)
+          .attr('x2', (d) => d.target.x)
+          .attr('y2', (d) => d.target.y)
 
-        edgepaths.attr('d', function (d) {
-          var path =
-            'M ' +
-            d.source.x +
-            ' ' +
-            d.source.y +
-            ' L ' +
-            d.target.x +
-            ' ' +
-            d.target.y
-          //console.log(d)
-          return path
-        })
+        if (edgepaths) {
+          edgepaths.attr(
+            'd',
+            (d) => `M ${d.source.x} ${d.source.y} L ${d.target.x} ${d.target.y}`
+          )
+        }
       }
       const simulation = forceSimulation().nodes(nodes)
 
@@ -161,20 +95,17 @@ const Graph = React.forwardRef((props, ref) => {
       const svg = select(ref.current)
       const g = svg.append('g')
       const paths = generatePaths(links, graph.nodes)
-      const edges = generateEdges(links, data.links)
+      // const edges = generateEdges(links, data.links)
 
       const link = g
         .selectAll('line')
         .data(links)
         .join('line')
         .attr('stroke', (d) => {
-          const st = d.source.id.lastIndexOf('-')
-          const dt = d.target.id.lastIndexOf('-')
-          const same = d.source.id.slice(0, st) === d.target.id.slice(0, dt)
+          const same = d.linkNum !== undefined
           if (same) {
-            const id = d.source.id.slice(0, st)
             const nodeIndex = paths.findIndex((path) => {
-              return path.original.id === id
+              return path.original.id === d.id
             })
             return color.startsWith('Just')
               ? color.replace('Just', '').toLowerCase()
@@ -186,10 +117,10 @@ const Graph = React.forwardRef((props, ref) => {
           }
         })
         .attr('stroke-width', (d) => {
-          const st = d.source.id.lastIndexOf('-')
-          const dt = d.target.id.lastIndexOf('-')
-          const same = d.source.id.slice(0, st) === d.target.id.slice(0, dt)
-          return same ? 10 : 1
+          return d.linkNum !== undefined ? sequenceThickness : linkThickness
+        })
+        .on('click', (event, d) => {
+          onFeatureClick(d)
         })
 
       const node = g
@@ -199,68 +130,39 @@ const Graph = React.forwardRef((props, ref) => {
         .attr('r', 5)
         .attr('fill', 'rgba(255,255,255,0.0)')
 
-      const edgepaths = g
-        .selectAll('.edgepath')
-        .data(links)
-        .enter()
-        .append('path')
-        .attr(
-          'd',
-          (d) =>
-            'M ' +
-            d.source.x +
-            ' ' +
-            d.source.y +
-            ' L ' +
-            d.target.x +
-            ' ' +
-            d.target.y
-        )
-        .attr('id', (d, i) => 'edgepath-' + i)
-      // .attr({
-      //   class: 'edgepath',
-      //   'fill-opacity': 0,
-      //   'stroke-opacity': 0,
-      //   fill: 'blue',
-      //   stroke: 'red',
-      //   id: function (d, i) {
-      //     return 'wowow' + i
-      //   }
-      // })
-      //
-      // .style('pointer-events', 'none')
-      // console.log({ edgepaths, links })
+      let edgepaths
+      if (drawLabels) {
+        edgepaths = g
+          .selectAll('.edgepath')
+          .data(links)
+          .enter()
+          .append('path')
+          .attr(
+            'd',
+            (d) => `M ${d.source.x} ${d.source.y} L ${d.target.x} ${d.target.y}`
+          )
+          .attr('id', (d, i) => 'edgepath-' + i)
 
-      const edgelabels = g
-        .selectAll('.edgelabel')
-        .data(links)
-        .enter()
-        .append('text')
-        .style('pointer-events', 'none')
-        .attr('id', (d, i) => 'edgelabel-' + i)
+        const edgelabels = g
+          .selectAll('.edgelabel')
+          .data(links)
+          .enter()
+          .append('text')
+          .style('pointer-events', 'none')
+          .attr('id', (d, i) => 'edgelabel-' + i)
 
-      console.log({ edgepaths, edgelabels })
-      // .attr({
-      //   class: 'edgelabel',
-      //   id: function (d, i) {
-      //     return 'edgelabel' + i
-      //   },
-      //   dx: 80,
-      //   dy: 0,
-      //   'font-size': 10,
-      //   fill: '#aaa'
-      // })
-
-      // console.log({ edgelabels })
-
-      // console.log({});
-      edgelabels
-        .append('textPath')
-        .attr('xlink:href', function (d, i) {
-          return '#edgepath-' + i
-        })
-        .style('pointer-events', 'none')
-        .text((d, i) => 'label ' + i)
+        edgelabels
+          .append('textPath')
+          .attr('xlink:href', (d, i) => `#edgepath-${i}`)
+          .style('pointer-events', 'none')
+          .text((d, i) => {
+            console.log({ d })
+            const sid = d.source.id.slice(0, d.source.id.lastIndexOf('-'))
+            const tid = d.target.id.slice(0, d.target.id.lastIndexOf('-'))
+            const same = sid === tid
+            return same ? sid : ''
+          })
+      }
 
       function drag_start(event, d) {
         if (!event.active) {
@@ -270,7 +172,6 @@ const Graph = React.forwardRef((props, ref) => {
         d.fy = event.y
       }
 
-      //make sure you can't drag the circle outside the box
       function drag_drag(event, d) {
         d.fx = event.x
         d.fy = event.y
@@ -282,7 +183,6 @@ const Graph = React.forwardRef((props, ref) => {
         d.fy = null
       }
 
-      //add drag capabilities
       var drag_handler = d3drag
         .drag()
         .on('start', drag_start)
@@ -292,14 +192,14 @@ const Graph = React.forwardRef((props, ref) => {
       drag_handler(node)
 
       if (drag) {
-        const zoomer = d3zoom()
-        zoomer.on('zoom', (event) => {
+        const zoom_handler = d3zoom()
+        zoom_handler.on('zoom', (event) => {
           if (drag) {
             g.attr('transform', event.transform)
           }
         })
 
-        zoomer(svg)
+        zoom_handler(svg)
       }
     }
   }, [
@@ -308,6 +208,7 @@ const Graph = React.forwardRef((props, ref) => {
     color,
     linkSteps,
     strengthCenter,
+    drawLabels,
     theta,
     forceType,
     width,
@@ -315,8 +216,7 @@ const Graph = React.forwardRef((props, ref) => {
     redraw,
     height,
     strengthXY,
-    forceSteps,
-    ref.current
+    forceSteps
   ])
   // const paths = generatePaths(links, graph.nodes)
   // const edges = generateEdges(links, data.links)

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -24,7 +24,6 @@ import {
 const { schemeCategory10 } = d3interpolate
 
 const Graph = React.forwardRef((props, ref) => {
-  const gref = useRef()
   const {
     graph,
     drawPaths = false,
@@ -61,14 +60,17 @@ const Graph = React.forwardRef((props, ref) => {
       })
     )
   }, [graph.paths])
+
+  console.log({ colors })
   useEffect(() => {
     if (ref.current) {
-      const links = data.links.map((d) =>
-        Object.create({ ...d, x: Math.random(), y: Math.random() })
-      )
-      const nodes = data.nodes.map((d) =>
-        Object.create({ ...d, x: Math.random(), y: Math.random() })
-      )
+      const links = data.links.map((d) => ({
+        ...d
+      }))
+      const nodes = data.nodes.map((d) => ({
+        ...d
+      }))
+
       // const simulation = forceSimulation(nodes)
       //   .force(
       //     'link',
@@ -132,7 +134,7 @@ const Graph = React.forwardRef((props, ref) => {
       const simulation = forceSimulation().nodes(nodes)
 
       const link_force = forceLink(links).id((d) => d.id)
-      const charge_force = forceManyBody().strength(-100)
+      const charge_force = forceManyBody().strength(-50)
       const center_force = forceCenter(width / 2, height / 2)
 
       simulation
@@ -146,30 +148,49 @@ const Graph = React.forwardRef((props, ref) => {
       const svg = select(ref.current)
       const g = svg.append('g')
 
+      const paths = generatePaths(links, graph.nodes)
       const link = g
         .append('g')
-        .attr('stroke', '#999')
-        .attr('stroke-opacity', 0.6)
         .selectAll('line')
         .data(links)
         .join('line')
+        .attr('stroke', (d) => {
+          const st = d.source.id.lastIndexOf('-')
+          const dt = d.target.id.lastIndexOf('-')
+          const same = d.source.id.slice(0, st) === d.target.id.slice(0, dt)
+          if (same) {
+            const id = d.source.id.slice(0, st)
+            const nodeIndex = paths.findIndex((path) => {
+              return path.original.id === id
+            })
+            return color.startsWith('Just')
+              ? color.replace('Just', '').toLowerCase()
+              : hsl(
+                  d3interpolate[`interpolate${color}`](nodeIndex / paths.length)
+                ).darker()
+          } else {
+            return 'grey'
+          }
+        })
+        .attr('stroke-width', (d) => {
+          const st = d.source.id.lastIndexOf('-')
+          const dt = d.target.id.lastIndexOf('-')
+          const same = d.source.id.slice(0, st) === d.target.id.slice(0, dt)
+          return same ? 10 : 1
+        })
 
       const node = g
         .append('g')
-        .attr('stroke', '#fff')
-        .attr('stroke-width', 1.5)
         .selectAll('circle')
         .data(nodes)
         .join('circle')
         .attr('r', 5)
-        .attr('fill', color)
+        .attr('fill', 'rgba(255,255,255,0.0)')
 
       function drag_start(event, d) {
         if (!event.active) {
           simulation.alphaTarget(0.3).restart()
         }
-        console.log({ d, event })
-
         d.fx = event.x
         d.fy = event.y
       }
@@ -215,6 +236,7 @@ const Graph = React.forwardRef((props, ref) => {
     forceType,
     width,
     drag,
+    redraw,
     height,
     strengthXY,
     forceSteps,
@@ -238,9 +260,7 @@ const Graph = React.forwardRef((props, ref) => {
       ref={ref}
       style={{ fontSize: 10 }}
       viewBox={[0, 0, width, height].toString()}
-    >
-      <g ref={gref}></g>
-    </svg>
+    ></svg>
   )
 })
 

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -10,13 +10,30 @@ import {
 } from 'd3-force'
 import * as d3interpolate from 'd3-scale-chromatic'
 import { zoom as d3zoom } from 'd3-zoom'
-import {
-  projectLine,
-  reprocessGraph,
-  generatePaths,
-  generateEdges
-} from './util'
+import { projectLine, reprocessGraph, generatePaths } from './util'
 const { schemeCategory10 } = d3interpolate
+
+function generateLinks(links) {
+  let newlinks = []
+  let pathIds = []
+  for (let i = 0; i < links.length; i++) {
+    const { paths, ...rest } = links[i]
+    if (paths) {
+      for (let j = 0; j < paths.length; j++) {
+        const pathId = paths[j]
+        let pathIndex = pathIds.indexOf(pathId)
+        if (pathIndex === -1) {
+          pathIds.push(pathId)
+          pathIndex = pathIds.length - 1
+        }
+        newlinks.push({ ...rest, pathId, pathIndex })
+      }
+    } else {
+      newlinks.push(rest)
+    }
+  }
+  return newlinks
+}
 
 const Graph = React.forwardRef((props, ref) => {
   const {
@@ -48,9 +65,20 @@ const Graph = React.forwardRef((props, ref) => {
     return reprocessGraph(graph, chunkSize)
   }, [chunkSize, graph])
 
+  const colors = useMemo(() => {
+    return Object.fromEntries(
+      (graph.paths || []).map((p, i) => {
+        return [p.name, schemeCategory10[i]]
+      })
+    )
+  }, [graph.paths])
+  console.log({ colors }, graph.paths)
+
   useEffect(() => {
     if (ref.current) {
-      // clone links+nodes so that redrawing will reposition them
+      // clone links+nodes because these contain an x,y coordinate that is
+      // physically modified by animation and so when we redraw/refresh, we
+      // want to put them back to normal
       const links = data.links.map((d) => ({
         ...d
       }))
@@ -65,35 +93,68 @@ const Graph = React.forwardRef((props, ref) => {
       function tickActions() {
         node.attr('cx', (d) => d.x).attr('cy', (d) => d.y)
 
+        const paths = generatePaths(links, graph.nodes)
+
+        const nodePathMap = {}
+        for (let i = 0; i < paths.length; i++) {
+          const p = paths[i]
+          const l = p.links.length
+          nodePathMap[`${p.original.id}-start`] = [p.links[1], p.links[0]]
+          nodePathMap[`${p.original.id}-end`] = [p.links[l - 2], p.links[l - 1]]
+        }
+
         // from https://stackoverflow.com/questions/16358905/
         link.attr('d', function (d) {
           const x1 = d.source.x
           const y1 = d.source.y
-          let x2 = d.target.x
-          let y2 = d.target.y
-          let drx = 0
-          let dry = 0
-          let xRotation = 0 // degrees
-          let largeArc = 0 // 1 or 0
-          const sweep = 0 // 1 or 0
+          const x2 = d.target.x
+          const y2 = d.target.y
+          if (d.pathIndex === undefined) {
+            let drx = 0
+            let dry = 0
+            let xRotation = 0 // degrees
+            let largeArc = 0 // 1 or 0
+            const sweep = 0 // 1 or 0
 
-          const sid = d.source.id.slice(0, d.source.id.lastIndexOf('-'))
-          const tid = d.target.id.slice(0, d.target.id.lastIndexOf('-'))
-          const same = sid === tid && !d.id
-          if (same) {
-            xRotation = -45
-            largeArc = 1
-            drx = 25
-            dry = 20
+            const sid = d.source.id.slice(0, d.source.id.lastIndexOf('-'))
+            const tid = d.target.id.slice(0, d.target.id.lastIndexOf('-'))
+            const same = sid === tid && !d.id
+            if (same) {
+              xRotation = -45
+              largeArc = 1
+              drx = 25
+              dry = 20
+            }
+
+            return `M${x1},${y1}A${drx},${dry},${xRotation},${largeArc},${sweep} ${x2},${y2}`
+          } else {
+            const [s1, t1] = nodePathMap[d.source.id]
+            const [s2, t2] = nodePathMap[d.target.id]
+            const [cx1, cy1] = projectLine(
+              s1[0],
+              s1[1],
+              t1[0],
+              t1[1],
+              60 + d.pathIndex * 30
+            )
+            const [cx2, cy2] = projectLine(
+              s2[0],
+              s2[1],
+              t2[0],
+              t2[1],
+              60 + d.pathIndex * 30
+            )
+
+            return `M ${x1} ${y1} C ${cx1} ${cy1}, ${cx2} ${cy2}, ${x2}, ${y2}`
           }
-
-          return `M${x1},${y1}A${drx},${dry},${xRotation},${largeArc},${sweep} ${x2},${y2}`
         })
+
+        link
 
         if (edgepaths) {
           edgepaths.attr(
             'd',
-            (d) => `M ${d.source.x} ${d.source.y} L ${d.target.x} ${d.target.y}`
+            (d) => `M${d.source.x},${d.source.y}L${d.target.x},${d.target.y}`
           )
         }
       }
@@ -115,41 +176,45 @@ const Graph = React.forwardRef((props, ref) => {
       const svg = select(ref.current)
       const g = svg.append('g')
       const paths = generatePaths(links, graph.nodes)
-      const edges = generateEdges(links, data.links)
-      console.log({ edges })
 
-      let link
-      if (!drawPaths) {
-        link = g
-          .selectAll('line')
-          .data(links)
-          .join('path')
-          .attr('stroke', (d) => {
-            const same = d.linkNum !== undefined
-            if (same) {
-              const nodeIndex = paths.findIndex((path) => {
-                return path.original.id === d.id
-              })
-              return color.startsWith('Just')
-                ? color.replace('Just', '').toLowerCase()
-                : hsl(
-                    d3interpolate[`interpolate${color}`](
-                      nodeIndex / paths.length
-                    )
-                  ).darker()
+      const nodePathMap = {}
+      for (let i = 0; i < paths.length; i++) {
+        const p = paths[i]
+        const l = p.links.length
+        nodePathMap[`${p.original.id}-start`] = [p.links[1], p.links[0]]
+        nodePathMap[`${p.original.id}-end`] = [p.links[l - 2], p.links[l - 1]]
+      }
+
+      const link = g
+        .selectAll('line')
+        .data(drawPaths ? generateLinks(links) : links)
+        .join('path')
+        .attr('stroke', (d) => {
+          const same = d.linkNum !== undefined
+          if (same) {
+            const nodeIndex = paths.findIndex((path) => {
+              return path.original.id === d.id
+            })
+            return color.startsWith('Just')
+              ? color.replace('Just', '').toLowerCase()
+              : hsl(
+                  d3interpolate[`interpolate${color}`](nodeIndex / paths.length)
+                ).darker()
+          } else {
+            if (drawPaths) {
+              return colors[d.pathId]
             } else {
               return 'grey'
             }
-          })
-          .attr('fill', 'none')
-          .attr('stroke-width', (d) => {
-            return d.linkNum !== undefined ? sequenceThickness : linkThickness
-          })
-          .on('click', (_, d) => {
-            onFeatureClick(d)
-          })
-      } else {
-      }
+          }
+        })
+        .attr('fill', 'none')
+        .attr('stroke-width', (d) => {
+          return d.linkNum !== undefined ? sequenceThickness : linkThickness
+        })
+        .on('click', (_, d) => {
+          onFeatureClick(d)
+        })
 
       const node = g
         .selectAll('circle')
@@ -165,7 +230,7 @@ const Graph = React.forwardRef((props, ref) => {
         .append('path')
         .attr(
           'd',
-          (d) => `M ${d.source.x} ${d.source.y} L ${d.target.x} ${d.target.y}`
+          (d) => `M${d.source.x},${d.source.y}L${d.target.x},${d.target.y}`
         )
         .attr('id', (_, i) => 'edgepath-' + i)
 
@@ -226,6 +291,7 @@ const Graph = React.forwardRef((props, ref) => {
     data.nodes,
     color,
     linkSteps,
+    drawPaths,
     strengthCenter,
     sequenceThickness,
     linkThickness,

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -1,6 +1,5 @@
 import React, { useMemo, useEffect } from 'react'
 import { hsl } from 'd3-color'
-import { path } from 'd3-path'
 import * as d3drag from 'd3-drag'
 import { select } from 'd3-selection'
 import {
@@ -11,14 +10,12 @@ import {
 } from 'd3-force'
 import * as d3interpolate from 'd3-scale-chromatic'
 import { zoom as d3zoom } from 'd3-zoom'
-import * as d3shape from 'd3-shape'
 import {
   projectLine,
   reprocessGraph,
   generatePaths,
   generateEdges
 } from './util'
-
 const { schemeCategory10 } = d3interpolate
 
 const Graph = React.forwardRef((props, ref) => {
@@ -50,7 +47,7 @@ const Graph = React.forwardRef((props, ref) => {
 
   useEffect(() => {
     if (ref.current) {
-      // clone nodes so that redrawing will reposition them
+      // clone links+nodes so that redrawing will reposition them
       const links = data.links.map((d) => ({
         ...d
       }))
@@ -58,64 +55,36 @@ const Graph = React.forwardRef((props, ref) => {
         ...d
       }))
 
+      // clear svg on each run
       ref.current.innerHTML = ''
+
+      // animation
       function tickActions() {
         node.attr('cx', (d) => d.x).attr('cy', (d) => d.y)
 
         // from https://stackoverflow.com/questions/16358905/
         link.attr('d', function (d) {
-          var x1 = d.source.x,
-            y1 = d.source.y,
-            x2 = d.target.x,
-            y2 = d.target.y,
-            drx = 0,
-            dry = 0,
-            xRotation = 0, // degrees
-            largeArc = 0, // 1 or 0
-            sweep = 1 // 1 or 0
+          const x1 = d.source.x
+          const y1 = d.source.y
+          let x2 = d.target.x
+          let y2 = d.target.y
+          let drx = 0
+          let dry = 0
+          let xRotation = 0 // degrees
+          let largeArc = 0 // 1 or 0
+          const sweep = 0 // 1 or 0
 
-          // Self edge.
-          if (x1 === x2 && y1 === y2) {
-            // Fiddle with this angle to get loop oriented.
+          const sid = d.source.id.slice(0, d.source.id.lastIndexOf('-'))
+          const tid = d.target.id.slice(0, d.target.id.lastIndexOf('-'))
+          const same = sid === tid && !d.id
+          if (same) {
             xRotation = -45
-
-            // Needs to be 1.
             largeArc = 1
-
-            // Change sweep to change orientation of loop.
-            //sweep = 0;
-
-            // Make drx and dry different to get an ellipse
-            // instead of a circle.
-            drx = 30
+            drx = 25
             dry = 20
-
-            // For whatever reason the arc collapses to a point if the beginning
-            // and ending points of the arc are the same, so kludge it.
-            x2 = x2 + 1
-            y2 = y2 + 1
           }
 
-          return (
-            'M' +
-            x1 +
-            ',' +
-            y1 +
-            'A' +
-            drx +
-            ',' +
-            dry +
-            ' ' +
-            xRotation +
-            ',' +
-            largeArc +
-            ',' +
-            sweep +
-            ' ' +
-            x2 +
-            ',' +
-            y2
-          )
+          return `M${x1},${y1}A${drx},${dry},${xRotation},${largeArc},${sweep} ${x2},${y2}`
         })
 
         if (edgepaths) {
@@ -164,6 +133,7 @@ const Graph = React.forwardRef((props, ref) => {
             return 'grey'
           }
         })
+        .attr('fill', 'none')
         .attr('stroke-width', (d) => {
           return d.linkNum !== undefined ? sequenceThickness : linkThickness
         })
@@ -175,41 +145,39 @@ const Graph = React.forwardRef((props, ref) => {
         .selectAll('circle')
         .data(nodes)
         .join('circle')
-        .attr('r', 5)
+        .attr('r', 7)
         .attr('fill', 'rgba(255,255,255,0.0)')
 
-      let edgepaths
-      if (drawLabels) {
-        edgepaths = g
-          .selectAll('.edgepath')
-          .data(links)
-          .enter()
-          .append('path')
-          .attr(
-            'd',
-            (d) => `M ${d.source.x} ${d.source.y} L ${d.target.x} ${d.target.y}`
-          )
-          .attr('id', (d, i) => 'edgepath-' + i)
+      const edgepaths = g
+        .selectAll('.edgepath')
+        .data(links)
+        .enter()
+        .append('path')
+        .attr(
+          'd',
+          (d) => `M ${d.source.x} ${d.source.y} L ${d.target.x} ${d.target.y}`
+        )
+        .attr('id', (d, i) => 'edgepath-' + i)
 
-        const edgelabels = g
-          .selectAll('.edgelabel')
-          .data(links)
-          .enter()
-          .append('text')
-          .style('pointer-events', 'none')
-          .attr('id', (d, i) => 'edgelabel-' + i)
+      const edgelabels = g
+        .selectAll('.edgelabel')
+        .data(links)
+        .enter()
+        .append('text')
+        .attr('dy', 12)
+        .attr('id', (d, i) => 'edgelabel-' + i)
 
-        edgelabels
-          .append('textPath')
-          .attr('xlink:href', (d, i) => `#edgepath-${i}`)
-          .style('pointer-events', 'none')
-          .text((d, i) => {
-            const sid = d.source.id.slice(0, d.source.id.lastIndexOf('-'))
-            const tid = d.target.id.slice(0, d.target.id.lastIndexOf('-'))
-            const same = sid === tid
-            return same ? sid : ''
-          })
-      }
+      edgelabels
+        .append('textPath')
+        .attr('href', (d, i) => `#edgepath-${i}`)
+        .attr('startOffset', '50%')
+        .attr('text-anchor', 'middle')
+        .text((d, i) => {
+          const sid = d.source.id.slice(0, d.source.id.lastIndexOf('-'))
+          const tid = d.target.id.slice(0, d.target.id.lastIndexOf('-'))
+          const same = sid === tid && d.id
+          return same ? sid : ''
+        })
 
       function drag_start(event, d) {
         if (!event.active) {
@@ -255,7 +223,6 @@ const Graph = React.forwardRef((props, ref) => {
     color,
     linkSteps,
     strengthCenter,
-    drawLabels,
     sequenceThickness,
     linkThickness,
     theta,
@@ -264,70 +231,15 @@ const Graph = React.forwardRef((props, ref) => {
     redraw,
     height
   ])
-  // const paths = generatePaths(links, graph.nodes)
-  // const edges = generateEdges(links, data.links)
-
-  // const nodePathMap = {}
-  // for (let i = 0; i < paths.length; i++) {
-  //   const p = paths[i]
-  //   const l = p.links.length
-  //   nodePathMap[`${p.original.id}-start`] = [p.links[1], p.links[0]]
-  //   nodePathMap[`${p.original.id}-end`] = [p.links[l - 2], p.links[l - 1]]
-  // }
 
   return (
     <svg
       width='100%'
       height='100%'
       ref={ref}
-      style={{ fontSize: 10 }}
-      viewBox={[0, 0, width, height].toString()}
+      style={{ fontSize: drawLabels ? 10 : 0 }}
     ></svg>
   )
 })
-
-function Path({ path, drawLabels, sequenceThickness, stroke, onFeatureClick }) {
-  const line = d3shape.line().context(null)
-  const t1 = path.links[0]
-  const s1 = path.links[1]
-  const t2 = path.links[path.links.length - 1]
-  const s2 = path.links[path.links.length - 2]
-  const [cx1, cy1] = projectLine(s1[0], s1[1], t1[0], t1[1], 100)
-  const [cx2, cy2] = projectLine(s2[0], s2[1], t2[0], t2[1], 100)
-  const invisibleTextPath = line([[cx1, cy1], ...path.links, [cx2, cy2]])
-
-  return (
-    <React.Fragment>
-      <path
-        id={path.original.id}
-        d={line(path.links)}
-        strokeWidth={sequenceThickness}
-        stroke={stroke}
-        fill='none'
-        onClick={() => onFeatureClick(path.original)}
-      >
-        <title>{path.original.id}</title>
-      </path>
-      {drawLabels ? (
-        <React.Fragment>
-          <path
-            id={`${path.original.id}_invisible`}
-            d={invisibleTextPath}
-            fill='none'
-          />
-          <text dy={12}>
-            <textPath
-              startOffset='50%'
-              textAnchor='middle'
-              href={`#${path.original.id}_invisible`}
-            >
-              {path.original.id}
-            </textPath>
-          </text>
-        </React.Fragment>
-      ) : null}
-    </React.Fragment>
-  )
-}
 
 export default Graph

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -130,6 +130,20 @@ const Graph = React.forwardRef((props, ref) => {
           .attr('y2', function (d) {
             return d.target.y
           })
+
+        edgepaths.attr('d', function (d) {
+          var path =
+            'M ' +
+            d.source.x +
+            ' ' +
+            d.source.y +
+            ' L ' +
+            d.target.x +
+            ' ' +
+            d.target.y
+          //console.log(d)
+          return path
+        })
       }
       const simulation = forceSimulation().nodes(nodes)
 
@@ -142,15 +156,14 @@ const Graph = React.forwardRef((props, ref) => {
         .force('center_force', center_force)
         .force('links', link_force)
 
-      //add tick instructions:
       simulation.on('tick', tickActions)
 
       const svg = select(ref.current)
       const g = svg.append('g')
-
       const paths = generatePaths(links, graph.nodes)
+      const edges = generateEdges(links, data.links)
+
       const link = g
-        .append('g')
         .selectAll('line')
         .data(links)
         .join('line')
@@ -180,12 +193,74 @@ const Graph = React.forwardRef((props, ref) => {
         })
 
       const node = g
-        .append('g')
         .selectAll('circle')
         .data(nodes)
         .join('circle')
         .attr('r', 5)
         .attr('fill', 'rgba(255,255,255,0.0)')
+
+      const edgepaths = g
+        .selectAll('.edgepath')
+        .data(links)
+        .enter()
+        .append('path')
+        .attr(
+          'd',
+          (d) =>
+            'M ' +
+            d.source.x +
+            ' ' +
+            d.source.y +
+            ' L ' +
+            d.target.x +
+            ' ' +
+            d.target.y
+        )
+        .attr('id', (d, i) => 'edgepath-' + i)
+      // .attr({
+      //   class: 'edgepath',
+      //   'fill-opacity': 0,
+      //   'stroke-opacity': 0,
+      //   fill: 'blue',
+      //   stroke: 'red',
+      //   id: function (d, i) {
+      //     return 'wowow' + i
+      //   }
+      // })
+      //
+      // .style('pointer-events', 'none')
+      // console.log({ edgepaths, links })
+
+      const edgelabels = g
+        .selectAll('.edgelabel')
+        .data(links)
+        .enter()
+        .append('text')
+        .style('pointer-events', 'none')
+        .attr('id', (d, i) => 'edgelabel-' + i)
+
+      console.log({ edgepaths, edgelabels })
+      // .attr({
+      //   class: 'edgelabel',
+      //   id: function (d, i) {
+      //     return 'edgelabel' + i
+      //   },
+      //   dx: 80,
+      //   dy: 0,
+      //   'font-size': 10,
+      //   fill: '#aaa'
+      // })
+
+      // console.log({ edgelabels })
+
+      // console.log({});
+      edgelabels
+        .append('textPath')
+        .attr('xlink:href', function (d, i) {
+          return '#edgepath-' + i
+        })
+        .style('pointer-events', 'none')
+        .text((d, i) => 'label ' + i)
 
       function drag_start(event, d) {
         if (!event.active) {
@@ -230,6 +305,7 @@ const Graph = React.forwardRef((props, ref) => {
   }, [
     data.links,
     data.nodes,
+    color,
     linkSteps,
     strengthCenter,
     theta,

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -185,6 +185,28 @@ const Graph = React.forwardRef((props, ref) => {
       simulation.on('tick', tickActions)
 
       const svg = select(ref.current)
+
+      //create arrowhead marker
+      svg
+        .append('defs')
+        .append('marker')
+        .attr('id', 'arrowhead')
+        .attr('viewBox', '-0 -5 10 10')
+        //the bound of the SVG viewport for the current SVG fragment. defines a
+        //coordinate system 10 wide and 10 high starting on (0,-5)
+        .attr('refX', 0)
+        // x coordinate for the reference point of the marker. If circle is
+        // bigger, this need to be bigger.
+        .attr('refY', 0)
+        .attr('orient', 'auto')
+        .attr('markerWidth', 2)
+        .attr('markerHeight', 2)
+        .attr('xoverflow', 'visible')
+        .append('svg:path')
+        .attr('d', 'M 0,-5 L 10 ,0 L 0,5')
+        .attr('fill', 'rgba(200,200,200,0.8)')
+        .style('stroke', 'none')
+
       const g = svg.append('g')
       const paths = generatePaths(links, graph.nodes)
 
@@ -197,9 +219,10 @@ const Graph = React.forwardRef((props, ref) => {
       }
 
       const link = g
-        .selectAll('line')
+        .selectAll('path')
         .data(drawPaths ? generateLinks(links) : links)
         .join('path')
+        .attr('marker-end', (d) => (d.id ? undefined : 'url(#arrowhead)'))
         .attr('stroke', (d) => {
           const same = d.linkNum !== undefined
           if (same) {
@@ -215,7 +238,7 @@ const Graph = React.forwardRef((props, ref) => {
             if (drawPaths) {
               return colors[d.pathId]
             } else {
-              return 'grey'
+              return 'rgba(200,200,200,0.8)'
             }
           }
         })

--- a/lib/src/util.js
+++ b/lib/src/util.js
@@ -38,7 +38,6 @@ export function reprocessGraph(G, chunkSize) {
         source,
         target,
         id,
-        name: id,
         length,
         sequence,
         linkNum: i

--- a/lib/src/util.js
+++ b/lib/src/util.js
@@ -38,6 +38,7 @@ export function reprocessGraph(G, chunkSize) {
         source,
         target,
         id,
+        name: id,
         length,
         sequence,
         linkNum: i
@@ -65,11 +66,12 @@ export function reprocessGraph(G, chunkSize) {
     }
     Gp.links.push(link)
   }
+
   return Gp
 }
 
-// source https://stackoverflow.com/questions/14446511/most-efficient-method-to-groupby-on-an-array-of-objects
-// returns an array that contains groupings of xs by attribute key
+// source https://stackoverflow.com/questions/14446511/ returns an array that
+// contains groupings of xs by attribute key
 function groupByArray(xs, key) {
   return xs.reduce(function (rv, x) {
     const v = key instanceof Function ? key(x) : x[key]


### PR DESCRIPTION
There was an attempt to "react-ize" the rendering of the graph but this resulted in a loss of being able to drag and position nodes. This is an attempt to restore some of that functionality. The drag handles are a bit weird but should be somewhat better than total inability to drag and drop

Also adds directional arrowheads and preserves path rendering

There are probably a couple accidentally quadratic things (ref https://accidentallyquadratic.tumblr.com/) but for small graphs works ok 